### PR TITLE
delete result csv file when test is successful

### DIFF
--- a/src/test/java/technology/tabula/TestCommandLineApp.java
+++ b/src/test/java/technology/tabula/TestCommandLineApp.java
@@ -64,6 +64,7 @@ public class TestCommandLineApp {
         Path csvPath = tmpFolder.resolve(fs.getPath("spreadsheet.csv"));
         assertTrue(csvPath.toFile().exists());
         assertArrayEquals(expectedCsv.getBytes(), Files.readAllBytes(csvPath));
+        Files.delete(csvPath);
     }
 
     @Test


### PR DESCRIPTION
This prevents leftover "tabula-java-batch-test568701853028748575" directories on Windows 10. Maybe the earlier "deleteOnExit()" works only on linux on non empty directories.